### PR TITLE
Misc Laravel 5.7 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Navigate to:
 
 ### Request Tracking Middleware
 
-To monitor your application's performance with request tracking, add the middleware to your application's *global* HTTP middleware stack , found in **app/Http/Kernel.php**:
+To monitor your application's performance with request tracking, add the middleware to your in your application, found in **app/Http/Kernel.php**. It has to be added after the StartSession middleware has been added.
 
 ```php
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/config": "~5.0",
         "illuminate/support": "~5.0",
         "laravel/framework": "~5.0",
-        "microsoft/application-insights": "^0.3.0"
+        "microsoft/application-insights": "^0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,16 @@
         "psr-4": {
             "Marchie\\MSApplicationInsightsLaravel\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Marchie\\MSApplicationInsightsLaravel\\Providers\\MSApplicationInsightsServiceProvider"
+            ],
+            "aliases": {
+                "AIClient": "Marchie\\MSApplicationInsightsLaravel\\Facades\\MSApplicationInsightsClientFacade",
+	        "AIServer": "Marchie\\MSApplicationInsightsLaravel\\Facades\\MSApplicationInsightsServerFacade"
+            }
+        }
     }
 }

--- a/src/MSApplicationInsightsHelpers.php
+++ b/src/MSApplicationInsightsHelpers.php
@@ -4,6 +4,8 @@ namespace Marchie\MSApplicationInsightsLaravel;
 use Exception;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class MSApplicationInsightsHelpers
 {
@@ -56,7 +58,7 @@ class MSApplicationInsightsHelpers
                     $request->fullUrl(),
                     $_SERVER['REQUEST_TIME_FLOAT'],
                     $this->getRequestDuration(),
-                    $response->status(),
+                    $this->getResponseCode($response),
                     $this->isSuccessful($response),
                     $this->getRequestProperties($request),
                     $this->getRequestMeasurements($request, $response)
@@ -225,7 +227,7 @@ class MSApplicationInsightsHelpers
      */
     private function isSuccessful($response)
     {
-        return ($response->status() < 400);
+        return ($this->getResponseCode($response) < 400);
     }
 
 
@@ -292,5 +294,18 @@ class MSApplicationInsightsHelpers
         $days = floor($duration / 86400);
 
         return $days . ':' . $string;
+    }
+
+    /**
+     * If you use stream() or streamDownload() then the response object isn't a standard one. Here we check different
+     * places for the status code depending on the object that Laravel sends us.
+     *
+     * @param StreamedResponse|Response $response The response object
+     *
+     * @return int The HTTP status code
+     */
+    private function getResponseCode($response)
+    {
+        return $response instanceof StreamedResponse ? $response->getStatusCode() : $response->status();
     }
 }


### PR DESCRIPTION
Here are a couple of fixes I've added to get this working in my application.

1) 05497f3 - Update dependencies so you can install - fixes conflicts in guzzle packages
2) 78160f7 - Add Laravel autodiscovery, which simplifies the installation of the package
3) f5a006c - Update the README.md as encountered an an issue where middleware session wasn't started before AppInsights were attempted which caused an error
```
Session store not set on request. in /code/app/vendor/laravel/framework/src/Illuminate/Http/Request.php on line 467
```
Moving `\Illuminate\Session\Middleware\StartSession::class` above the `MSApplicationInsightsMiddleware::class` fixed this.

4) b06a44c - This was an interesting one. Using stream() or streamDownload() as per the [Laravel Documentation](https://laravel.com/docs/5.7/responses#file-downloads) causes an error. This is because the response object is no longer a Laravel one, but the Symfony streaming response. The code in the Helpers class assumes `->status()` exists but that is the Laravel one specific. This change checks what the `$response` class is and alters where it looks for the status code if a stream.

Happy for feedback

Dave