### PR TITLE
Implemented workaround for breaking change in Exception Handler in Laravel 5.3.

### DIFF
--- a/src/Handlers/MSApplicationInsightsExceptionHandler.php
+++ b/src/Handlers/MSApplicationInsightsExceptionHandler.php
@@ -5,6 +5,7 @@ use Exception;
 use Marchie\MSApplicationInsightsLaravel\MSApplicationInsightsHelpers;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class MSApplicationInsightsExceptionHandler extends ExceptionHandler
@@ -16,10 +17,17 @@ class MSApplicationInsightsExceptionHandler extends ExceptionHandler
     private $msApplicationInsightsHelpers;
 
 
-    public function __construct(MSApplicationInsightsHelpers $msApplicationInsightsHelpers, LoggerInterface $log)
+    public function __construct(MSApplicationInsightsHelpers $msApplicationInsightsHelpers, LoggerInterface $log, Container $container)
     {
         $this->msApplicationInsightsHelpers = $msApplicationInsightsHelpers;
-        parent::__construct($log);
+
+        // Laravel 5.3 introduced a breaking change in the Exception Handler constructor.
+        // See the section 'Exception Handler'->'Constructor' in https://laravel.com/docs/5.3/upgrade#upgrade-5.3.0
+        if (version_compare(app()->version(), '5.3.0', '>=')) {
+            parent::__construct($container);
+        } else {
+            parent::__construct($log);
+        }
     }
 
     /**


### PR DESCRIPTION
Laravel 5.3 introduced a breaking change in the Exception Handler constructor.
See the section 'Exception Handler'->'Constructor' in https://laravel.com/docs/5.3/upgrade#upgrade-5.3.0

Fixes #1 